### PR TITLE
build: add typing-extensions as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ classifiers = [
 dependencies = [
     "httpx>=0.23.0,<0.29.0",
     "attrs>=25.4.0",
-    "python-dateutil>=2.8.0,<3.0.0"
+    "python-dateutil>=2.8.0,<3.0.0",
+    "typing-extensions>=4.0.0,<5.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -242,12 +242,13 @@ wheels = [
 
 [[package]]
 name = "metrotransit"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
     { name = "httpx" },
     { name = "python-dateutil" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -261,6 +262,7 @@ requires-dist = [
     { name = "attrs", specifier = ">=25.4.0" },
     { name = "httpx", specifier = ">=0.23.0,<0.29.0" },
     { name = "python-dateutil", specifier = ">=2.8.0,<3.0.0" },
+    { name = "typing-extensions", specifier = ">=4.0.0,<5.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Fixes #1.

All this project uses is `typing_extensions.Self`, which was added in 4.0.0 according to [their docs](https://typing-extensions.readthedocs.io/en/latest/index.html#typing_extensions.Self). Therefore, I've added `typing-extensions>=4.0.0,<5.0.0` as a project dependency.